### PR TITLE
Update poetry.lock jinja2 version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -38,7 +38,7 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"


### PR DESCRIPTION
GitHub security alert digest reports that <-3.1.4 should upgrade to 3.1.5.