### PR TITLE
feat: add --focus to only run permutations involving one implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ option. The default is 10 seconds.
 
 Use `poetry run plummet --help` to list all command line options.
 
+If you only care about how a single implementation behaves, running the full
+matrix of every client against every server is wasteful. Pass
+`--focus <implementation>` to still consider all implementations, but only
+execute and report permutations where `<implementation>` is the client or the
+server, e.g. `poetry run plummet --focus pyroughtime`.
+
 When everything is done, the `results` folder have a subdirectory based on the
 start time containing each permutation tested. Your console will be filled of
 angry messages, but you should be satisfied. Now take your time, read the log

--- a/etc/template_results.html
+++ b/etc/template_results.html
@@ -23,11 +23,14 @@
     <tr>
       <td>{{ s }}</td>
       {% for c in clients %}
-        {% if results[s][c].result == 'success' %}
+        {% set r = results.get(s, {}).get(c) %}
+        {% if r is none %}
+          <td>&mdash;</td>
+        {% elif r.result == 'success' %}
           <td><a href="#{{s}}_{{c}}">&#9989;</a></td>
-        {% elif results[s][c].result == 'failure' %}
+        {% elif r.result == 'failure' %}
           <td><a href="#{{s}}_{{c}}">&#10060;</a></td>
-        {% elif results[s][c].result == 'unknown' %}
+        {% elif r.result == 'unknown' %}
           <td><a href="#{{s}}_{{c}}">&#10067;</a></td>
         {% else %}
           <td><a href="#{{s}}_{{c}}">&#10071;</a></td>
@@ -39,7 +42,8 @@
   </div>
   {% for s in servers %}
     {% for c in clients %}
-      {% set r = results[s][c] %}
+      {% set r = results.get(s, {}).get(c) %}
+      {% if r is not none %}
       <div style="border: 2px solid gray; border-radius: 25px; padding: 10px; margin-bottom: 25px;">
       <a name="{{s}}_{{c}}"></a>
       <p>
@@ -68,6 +72,7 @@
       </pre>
       {% endfor %}
       </div>
+      {% endif %}
     {% endfor %}
   {% endfor %}
 </body>

--- a/plummet/cli.py
+++ b/plummet/cli.py
@@ -18,7 +18,7 @@ import jinja2
 import pyroughtime  # type: ignore[import]
 import scapy.utils
 import yaml
-from scapy.layers.inet import UDP, TCP
+from scapy.layers.inet import TCP, UDP
 
 CMD_INFO = """
 plummet takes all the known roughtime implementations and attempts to perform
@@ -77,7 +77,12 @@ def main() -> None:
 
     # Generate all the permutations of client and servers
     implementations: Implementations = args.impls["implementations"]
-    permutations = generate_permutations(implementations)
+
+    if args.focus is not None and args.focus not in implementations:
+        logger.critical(f"--focus implementation '{args.focus}' is not known, exiting...")
+        sys.exit(1)
+
+    permutations = generate_permutations(implementations, focus=args.focus)
 
     # Prepare the location
     start_time = datetime.datetime.now(datetime.timezone.utc)
@@ -234,6 +239,15 @@ def parse_args():
         "--verbose", action=argparse.BooleanOptionalAction, help="Enable more verbosity"
     )
     parser.add_argument(
+        "--focus",
+        type=str,
+        default=None,
+        help=(
+            "Only run permutations where this implementation is the client or "
+            "the server instead of the full matrix."
+        ),
+    )
+    parser.add_argument(
         "--workers",
         type=int,
         default=1,
@@ -332,13 +346,18 @@ def run_permutation(
 
 
 # For each implementation that we know of, based on it having a client and/or
-# server, work out permutations of all.
-def generate_permutations(impls: Implementations) -> list[Permutation]:
+# server, work out permutations of all. If focus is given, restrict the
+# result to permutations where that implementation is the client or server.
+def generate_permutations(
+    impls: Implementations, focus: str | None = None
+) -> list[Permutation]:
     permutations: list[Permutation] = []
     for server_name, server in impls.items():
         if server["enabled"] and server["server"]:
             for client_name, client in impls.items():
                 if client["enabled"] and client["client"]:
+                    if focus is not None and focus not in (server_name, client_name):
+                        continue
                     permutations.append(
                         {
                             "server": server_name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,3 +13,16 @@ def test_generate_permutations():
     ]
     actual = cli.generate_permutations(mock_impls)
     assert expected == actual
+
+
+def test_generate_permutations_focus():
+    mock_impls = {
+        'bianchini': {'enabled': True, 'client': True, 'server': True},
+        'huyghens': {'enabled': True, 'client': True, 'server': False},
+        'jang': {'enabled': True, 'client': True, 'server': True}
+    }
+    actual = cli.generate_permutations(mock_impls, focus='huyghens')
+    assert {p['server'] for p in actual} <= {'bianchini', 'jang'}
+    assert all(p['client'] == 'huyghens' for p in actual)
+    assert len(actual) == 2
+


### PR DESCRIPTION
Adds a `--focus <implementation>` flag to restrict which permutations get executed to those where `<implementation>` is the client or the server.

Also: `template_results.html` now handles missing results for a permutation and just renders a `—` instead of crashing.


### Rationale
I run plummet in CI (https://github.com/teaishealthy/roughly/blob/main/.github/workflows/interop.yml) to see how a change affects interop, but I have to pay the full matrix price every time I want a "quick" signal.

`--focus` now gives n + k runs instead of n * k

For the current implementations.yml (7 servers, 8 clients, 56 total permutations), this means:

- server-only: 8 runs (7x reduction)
- client-only: 7 runs (8x reduction)
- both: 14 runs (4x reduction)

You can see a `--focus` run at https://github.com/teaishealthy/roughly/actions/runs/29692084818
Run results are uploaded as artifacts.